### PR TITLE
feat(13): EASM get_leaked_credentials get_issues_discovered and timestamp filters for multiple operations incorporated

### DIFF
--- a/fortinet-fortirecon-easm/info.json
+++ b/fortinet-fortirecon-easm/info.json
@@ -77,7 +77,8 @@
             "breach_id": "",
             "breach_date": "",
             "breach_name": "",
-            "has_password": ""
+            "has_password": "",
+            "plaintext_passwords": []
           }
         ]
       },
@@ -150,6 +151,20 @@
           "options": [
             "True",
             "False"
+          ]
+        },
+        {
+          "name": "show_plaintext_password",
+          "title": "Show plaintext password",
+          "type": "select",
+          "editable": true,
+          "visible": true,
+          "required": false,
+          "tooltip": "Select true if plaintext password needs to show in response. Default is false.",
+          "description": "(Optional) Select true if plaintext password needs to show in response.",
+          "options": [
+            "false",
+            "true"
           ]
         },
         {

--- a/fortinet-fortirecon-easm/info.json
+++ b/fortinet-fortirecon-easm/info.json
@@ -590,7 +590,9 @@
         "status": "",
         "user_name": "",
         "issue_name_identifier": "",
-        "bucket_id": ""
+        "bucket_id": "",
+        "created_ts": "",
+        "modified_ts": ""
       },
       "parameters": [
         {
@@ -883,7 +885,9 @@
               }
             ],
             "user_action": "",
-            "user_name": ""
+            "user_name": "",
+            "created_ts": "",
+            "modified_ts": ""
           }
         ],
         "page": "",
@@ -978,6 +982,28 @@
           "description": "(Optional) Specify the group ID to filter retrieved results. You can specify multiple group IDs as comma-separated values. It returns results if it matches all of the specified groups, operating as an 'AND filter'."
         },
         {
+          "title": "Create timestamp",
+          "name": "created_ts",
+          "type": "text",
+          "visible": true,
+          "editable": true,
+          "required": false,
+          "placeholder": "Format: YYYY-MM-DDTHH:MM:SS TO YYYY-MM-DDTHH:MM:SS",
+          "tooltip": "Range consists of start_date and end_date separated by `TO`. Both start and end values can be in either date-only or full datetime format.",
+          "description": "Filter by created_ts datetime range. Accepted formats: (`YYYY-MM-DDTHH:MM:SS TO YYYY-MM-DDTHH:MM:SS`), (`YYYY-MM-DD TO YYYY-MM-DD`). Example: (`2022-03-25T09:50:21.770+00:00 TO 2022-03-25T14:24:05.000+00:00`, `2022-03-25TO2022-03-25T14:24:05.000+00:00`, `2022-03-25 TO 2022-03-25`)"
+        },
+        {
+          "title": "Modified timestamp",
+          "name": "modified_ts",
+          "type": "text",
+          "visible": true,
+          "editable": true,
+          "required": false,
+          "placeholder": "Format: YYYY-MM-DDTHH:MM:SS TO YYYY-MM-DDTHH:MM:SS",
+          "tooltip": "Range consists of start_date and end_date separated by `TO`. Both start and end values can be in either date-only or full datetime format.",
+          "description": "Filter by modified datetime range. Accepted formats: (`YYYY-MM-DDTHH:MM:SS TO YYYY-MM-DDTHH:MM:SS`), (`YYYY-MM-DD TO YYYY-MM-DD`). Example: (`2022-03-25T09:50:21.770+00:00 TO 2022-03-25T14:24:05.000+00:00`, `2022-03-25TO2022-03-25T14:24:05.000+00:00`, `2022-03-25 TO 2022-03-25`)"
+        },
+        {
           "name": "page",
           "value": 1,
           "title": "Page",
@@ -1025,6 +1051,8 @@
               }
             ],
             "id": "",
+            "created_ts": "",
+            "modified_ts": "",
             "tags": [
               {
                 "id": "",
@@ -1148,6 +1176,28 @@
           "description": "(Optional) Specify the cloud metadata in JSON format to filter the results. Available fields are: integration_id, cloud_provider, account_id, resource_id, resource_group, resource_name, resource_type, region, and subscription_id. For example: { \"cloud_provider\": [ \"azure\" ], \"region\": [ \"westus2\" ], \"integration_id\": [ \"777408f550e5rrdd1hjf3w90\" ], \"resource_name\": [ \"TestAssetsPublic\" ] }"
         },
         {
+          "title": "Create timestamp",
+          "name": "created_ts",
+          "type": "text",
+          "visible": true,
+          "editable": true,
+          "required": false,
+          "placeholder": "Format: YYYY-MM-DDTHH:MM:SS TO YYYY-MM-DDTHH:MM:SS",
+          "tooltip": "Range consists of start_date and end_date separated by `TO`. Both start and end values can be in either date-only or full datetime format.",
+          "description": "Filter by created_ts datetime range. Accepted formats: (`YYYY-MM-DDTHH:MM:SS TO YYYY-MM-DDTHH:MM:SS`), (`YYYY-MM-DD TO YYYY-MM-DD`). Example: (`2022-03-25T09:50:21.770+00:00 TO 2022-03-25T14:24:05.000+00:00`, `2022-03-25TO2022-03-25T14:24:05.000+00:00`, `2022-03-25 TO 2022-03-25`)"
+        },
+        {
+          "title": "Modified timestamp",
+          "name": "modified_ts",
+          "type": "text",
+          "visible": true,
+          "editable": true,
+          "required": false,
+          "placeholder": "Format: YYYY-MM-DDTHH:MM:SS TO YYYY-MM-DDTHH:MM:SS",
+          "tooltip": "Range consists of start_date and end_date separated by `TO`. Both start and end values can be in either date-only or full datetime format.",
+          "description": "Filter by modified datetime range. Accepted formats: (`YYYY-MM-DDTHH:MM:SS TO YYYY-MM-DDTHH:MM:SS`), (`YYYY-MM-DD TO YYYY-MM-DD`). Example: (`2022-03-25T09:50:21.770+00:00 TO 2022-03-25T14:24:05.000+00:00`, `2022-03-25TO2022-03-25T14:24:05.000+00:00`, `2022-03-25 TO 2022-03-25`)"
+        },
+        {
           "name": "page",
           "value": 1,
           "title": "Page",
@@ -1202,6 +1252,8 @@
             "assets_linked_count": "",
             "company_name": "",
             "fgt_metadata": {},
+            "created_ts": "",
+            "modified_ts": "",
             "discovery_path": [
               {
                 "source": "",
@@ -1331,7 +1383,9 @@
                 "name": ""
               }
             ],
-            "technologies": []
+            "technologies": [],
+            "created_ts": "",
+            "modified_ts": ""
           }
         ],
         "page": "",
@@ -1498,6 +1552,28 @@
           "description": "(Optional) Specify the cloud metadata in JSON format to filter the results. Available fields are: integration_id, cloud_provider, account_id, resource_id, resource_group, resource_name, resource_type, region, and subscription_id. For example: { \"cloud_provider\": [ \"azure\" ], \"region\": [ \"westus2\" ], \"integration_id\": [ \"777408f550e5rrdd1hjf3w90\" ], \"resource_name\": [ \"TestAssetsPublic\" ] }"
         },
         {
+          "title": "Create timestamp",
+          "name": "created_ts",
+          "type": "text",
+          "visible": true,
+          "editable": true,
+          "required": false,
+          "placeholder": "Format: YYYY-MM-DDTHH:MM:SS TO YYYY-MM-DDTHH:MM:SS",
+          "tooltip": "Range consists of start_date and end_date separated by `TO`. Both start and end values can be in either date-only or full datetime format.",
+          "description": "Filter by created_ts datetime range. Accepted formats: (`YYYY-MM-DDTHH:MM:SS TO YYYY-MM-DDTHH:MM:SS`), (`YYYY-MM-DD TO YYYY-MM-DD`). Example: (`2022-03-25T09:50:21.770+00:00 TO 2022-03-25T14:24:05.000+00:00`, `2022-03-25TO2022-03-25T14:24:05.000+00:00`, `2022-03-25 TO 2022-03-25`)"
+        },
+        {
+          "title": "Modified timestamp",
+          "name": "modified_ts",
+          "type": "text",
+          "visible": true,
+          "editable": true,
+          "required": false,
+          "placeholder": "Format: YYYY-MM-DDTHH:MM:SS TO YYYY-MM-DDTHH:MM:SS",
+          "tooltip": "Range consists of start_date and end_date separated by `TO`. Both start and end values can be in either date-only or full datetime format.",
+          "description": "Filter by modified datetime range. Accepted formats: (`YYYY-MM-DDTHH:MM:SS TO YYYY-MM-DDTHH:MM:SS`), (`YYYY-MM-DD TO YYYY-MM-DD`). Example: (`2022-03-25T09:50:21.770+00:00 TO 2022-03-25T14:24:05.000+00:00`, `2022-03-25TO2022-03-25T14:24:05.000+00:00`, `2022-03-25 TO 2022-03-25`)"
+        },
+        {
           "name": "page",
           "value": 1,
           "title": "Page",
@@ -1586,6 +1662,8 @@
             },
             "assets_linked_count": "",
             "issue_count": "",
+            "created_ts": "",
+            "modified_ts": "",
             "discovery_path": [
               {
                 "source": "",
@@ -1722,7 +1800,9 @@
             "cloud_metadata": {},
             "fgt_metadata": {},
             "assets_linked_count": "",
-            "version": ""
+            "version": "",
+            "created_ts": "",
+            "modified_ts": ""
           }
         ]
       },
@@ -1911,6 +1991,28 @@
           "description": "(Optional) Specify the cloud metadata in JSON format to filter the results. Available fields are: integration_id, cloud_provider, account_id, resource_id, resource_group, resource_name, resource_type, region, and subscription_id. For example: { \"cloud_provider\": [ \"azure\" ], \"region\": [ \"westus2\" ], \"integration_id\": [ \"777408f550e5rrdd1hjf3w90\" ], \"resource_name\": [ \"TestAssetsPublic\" ] }"
         },
         {
+          "title": "Create timestamp",
+          "name": "created_ts",
+          "type": "text",
+          "visible": true,
+          "editable": true,
+          "required": false,
+          "placeholder": "Format: YYYY-MM-DDTHH:MM:SS TO YYYY-MM-DDTHH:MM:SS",
+          "tooltip": "Range consists of start_date and end_date separated by `TO`. Both start and end values can be in either date-only or full datetime format.",
+          "description": "Filter by created_ts datetime range. Accepted formats: (`YYYY-MM-DDTHH:MM:SS TO YYYY-MM-DDTHH:MM:SS`), (`YYYY-MM-DD TO YYYY-MM-DD`). Example: (`2022-03-25T09:50:21.770+00:00 TO 2022-03-25T14:24:05.000+00:00`, `2022-03-25TO2022-03-25T14:24:05.000+00:00`, `2022-03-25 TO 2022-03-25`)"
+        },
+        {
+          "title": "Modified timestamp",
+          "name": "modified_ts",
+          "type": "text",
+          "visible": true,
+          "editable": true,
+          "required": false,
+          "placeholder": "Format: YYYY-MM-DDTHH:MM:SS TO YYYY-MM-DDTHH:MM:SS",
+          "tooltip": "Range consists of start_date and end_date separated by `TO`. Both start and end values can be in either date-only or full datetime format.",
+          "description": "Filter by modified datetime range. Accepted formats: (`YYYY-MM-DDTHH:MM:SS TO YYYY-MM-DDTHH:MM:SS`), (`YYYY-MM-DD TO YYYY-MM-DD`). Example: (`2022-03-25T09:50:21.770+00:00 TO 2022-03-25T14:24:05.000+00:00`, `2022-03-25TO2022-03-25T14:24:05.000+00:00`, `2022-03-25 TO 2022-03-25`)"
+        },
+        {
           "name": "page",
           "value": 1,
           "title": "Page",
@@ -1964,6 +2066,8 @@
             "assets_linked_count": "",
             "version": "",
             "issue_count": "",
+            "created_ts": "",
+            "modified_ts": "",
             "discovery_path": [
               {
                 "source": "",
@@ -2068,7 +2172,9 @@
                 "name": ""
               }
             ],
-            "version": ""
+            "version": "",
+            "created_ts": "",
+            "modified_ts": ""
           }
         ],
         "page": "",
@@ -2211,6 +2317,28 @@
           "description": "(Optional) Specify the cloud metadata in JSON format to filter the results. Available fields are: integration_id, cloud_provider, account_id, resource_id, resource_group, resource_name, resource_type, region, and subscription_id. For example: { \"cloud_provider\": [ \"azure\" ], \"region\": [ \"westus2\" ], \"integration_id\": [ \"777408f550e5rrdd1hjf3w90\" ], \"resource_name\": [ \"TestAssetsPublic\" ] }"
         },
         {
+          "title": "Create timestamp",
+          "name": "created_ts",
+          "type": "text",
+          "visible": true,
+          "editable": true,
+          "required": false,
+          "placeholder": "Format: YYYY-MM-DDTHH:MM:SS TO YYYY-MM-DDTHH:MM:SS",
+          "tooltip": "Range consists of start_date and end_date separated by `TO`. Both start and end values can be in either date-only or full datetime format.",
+          "description": "Filter by created_ts datetime range. Accepted formats: (`YYYY-MM-DDTHH:MM:SS TO YYYY-MM-DDTHH:MM:SS`), (`YYYY-MM-DD TO YYYY-MM-DD`). Example: (`2022-03-25T09:50:21.770+00:00 TO 2022-03-25T14:24:05.000+00:00`, `2022-03-25TO2022-03-25T14:24:05.000+00:00`, `2022-03-25 TO 2022-03-25`)"
+        },
+        {
+          "title": "Modified timestamp",
+          "name": "modified_ts",
+          "type": "text",
+          "visible": true,
+          "editable": true,
+          "required": false,
+          "placeholder": "Format: YYYY-MM-DDTHH:MM:SS TO YYYY-MM-DDTHH:MM:SS",
+          "tooltip": "Range consists of start_date and end_date separated by `TO`. Both start and end values can be in either date-only or full datetime format.",
+          "description": "Filter by modified datetime range. Accepted formats: (`YYYY-MM-DDTHH:MM:SS TO YYYY-MM-DDTHH:MM:SS`), (`YYYY-MM-DD TO YYYY-MM-DD`). Example: (`2022-03-25T09:50:21.770+00:00 TO 2022-03-25T14:24:05.000+00:00`, `2022-03-25TO2022-03-25T14:24:05.000+00:00`, `2022-03-25 TO 2022-03-25`)"
+        },
+        {
           "name": "page",
           "value": 1,
           "title": "Page",
@@ -2277,7 +2405,9 @@
                 "target": "",
                 "data_type": ""
               }
-            ]
+            ],
+            "created_ts": "",
+            "modified_ts": ""
           }
         },
         {
@@ -2313,7 +2443,9 @@
                 "data_type": ""
               }
             ],
-            "assets_linked_count": ""
+            "assets_linked_count": "",
+            "created_ts": "",
+            "modified_ts": ""
           }
         }
       ],
@@ -2367,7 +2499,9 @@
             "domain_name": "",
             "fgt_metadata": {},
             "technologies": [],
-            "cloud_metadata": {}
+            "cloud_metadata": {},
+            "created_ts": "",
+            "modified_ts": ""
           }
         ],
         "page": "",
@@ -2544,6 +2678,28 @@
           "description": "(Optional) Specify the cloud metadata in JSON format to filter the results. Available fields are: integration_id, cloud_provider, account_id, resource_id, resource_group, resource_name, resource_type, region, and subscription_id. For example: { \"cloud_provider\": [ \"azure\" ], \"region\": [ \"westus2\" ], \"integration_id\": [ \"777408f550e5rrdd1hjf3w90\" ], \"resource_name\": [ \"TestAssetsPublic\" ] }"
         },
         {
+          "title": "Create timestamp",
+          "name": "created_ts",
+          "type": "text",
+          "visible": true,
+          "editable": true,
+          "required": false,
+          "placeholder": "Format: YYYY-MM-DDTHH:MM:SS TO YYYY-MM-DDTHH:MM:SS",
+          "tooltip": "Range consists of start_date and end_date separated by `TO`. Both start and end values can be in either date-only or full datetime format.",
+          "description": "Filter by created_ts datetime range. Accepted formats: (`YYYY-MM-DDTHH:MM:SS TO YYYY-MM-DDTHH:MM:SS`), (`YYYY-MM-DD TO YYYY-MM-DD`). Example: (`2022-03-25T09:50:21.770+00:00 TO 2022-03-25T14:24:05.000+00:00`, `2022-03-25TO2022-03-25T14:24:05.000+00:00`, `2022-03-25 TO 2022-03-25`)"
+        },
+        {
+          "title": "Modified timestamp",
+          "name": "modified_ts",
+          "type": "text",
+          "visible": true,
+          "editable": true,
+          "required": false,
+          "placeholder": "Format: YYYY-MM-DDTHH:MM:SS TO YYYY-MM-DDTHH:MM:SS",
+          "tooltip": "Range consists of start_date and end_date separated by `TO`. Both start and end values can be in either date-only or full datetime format.",
+          "description": "Filter by modified datetime range. Accepted formats: (`YYYY-MM-DDTHH:MM:SS TO YYYY-MM-DDTHH:MM:SS`), (`YYYY-MM-DD TO YYYY-MM-DD`). Example: (`2022-03-25T09:50:21.770+00:00 TO 2022-03-25T14:24:05.000+00:00`, `2022-03-25TO2022-03-25T14:24:05.000+00:00`, `2022-03-25 TO 2022-03-25`)"
+        },
+        {
           "name": "page",
           "value": 1,
           "title": "Page",
@@ -2602,7 +2758,9 @@
             "target": "",
             "data_type": ""
           }
-        ]
+        ],
+        "created_ts": "",
+        "modified_ts": ""
       },
       "parameters": [
         {
@@ -3215,7 +3373,9 @@
             "provider": "",
             "account_id": "",
             "policy_errors": [],
-            "connection_status": ""
+            "connection_status": "",
+            "created_ts": "",
+            "modified_ts": ""
           }
         ],
         "page": "",
@@ -3251,6 +3411,28 @@
             "Failed",
             "Success"
           ]
+        },
+        {
+          "title": "Create timestamp",
+          "name": "created_ts",
+          "type": "text",
+          "visible": true,
+          "editable": true,
+          "required": false,
+          "placeholder": "Format: YYYY-MM-DDTHH:MM:SS TO YYYY-MM-DDTHH:MM:SS",
+          "tooltip": "Range consists of start_date and end_date separated by `TO`. Both start and end values can be in either date-only or full datetime format.",
+          "description": "Filter by created_ts datetime range. Accepted formats: (`YYYY-MM-DDTHH:MM:SS TO YYYY-MM-DDTHH:MM:SS`), (`YYYY-MM-DD TO YYYY-MM-DD`). Example: (`2022-03-25T09:50:21.770+00:00 TO 2022-03-25T14:24:05.000+00:00`, `2022-03-25TO2022-03-25T14:24:05.000+00:00`, `2022-03-25 TO 2022-03-25`)"
+        },
+        {
+          "title": "Modified timestamp",
+          "name": "modified_ts",
+          "type": "text",
+          "visible": true,
+          "editable": true,
+          "required": false,
+          "placeholder": "Format: YYYY-MM-DDTHH:MM:SS TO YYYY-MM-DDTHH:MM:SS",
+          "tooltip": "Range consists of start_date and end_date separated by `TO`. Both start and end values can be in either date-only or full datetime format.",
+          "description": "Filter by modified datetime range. Accepted formats: (`YYYY-MM-DDTHH:MM:SS TO YYYY-MM-DDTHH:MM:SS`), (`YYYY-MM-DD TO YYYY-MM-DD`). Example: (`2022-03-25T09:50:21.770+00:00 TO 2022-03-25T14:24:05.000+00:00`, `2022-03-25TO2022-03-25T14:24:05.000+00:00`, `2022-03-25 TO 2022-03-25`)"
         },
         {
           "name": "page",
@@ -3295,7 +3477,9 @@
             "is_ssl": "",
             "verify_ssl": "",
             "policy_errors": [],
-            "connection_status": ""
+            "connection_status": "",
+            "created_ts": "",
+            "modified_ts": ""
           }
         ],
         "page": "",
@@ -3316,6 +3500,28 @@
             "Failed",
             "Success"
           ]
+        },
+        {
+          "title": "Create timestamp",
+          "name": "created_ts",
+          "type": "text",
+          "visible": true,
+          "editable": true,
+          "required": false,
+          "placeholder": "Format: YYYY-MM-DDTHH:MM:SS TO YYYY-MM-DDTHH:MM:SS",
+          "tooltip": "Range consists of start_date and end_date separated by `TO`. Both start and end values can be in either date-only or full datetime format.",
+          "description": "Filter by created_ts datetime range. Accepted formats: (`YYYY-MM-DDTHH:MM:SS TO YYYY-MM-DDTHH:MM:SS`), (`YYYY-MM-DD TO YYYY-MM-DD`). Example: (`2022-03-25T09:50:21.770+00:00 TO 2022-03-25T14:24:05.000+00:00`, `2022-03-25TO2022-03-25T14:24:05.000+00:00`, `2022-03-25 TO 2022-03-25`)"
+        },
+        {
+          "title": "Modified timestamp",
+          "name": "modified_ts",
+          "type": "text",
+          "visible": true,
+          "editable": true,
+          "required": false,
+          "placeholder": "Format: YYYY-MM-DDTHH:MM:SS TO YYYY-MM-DDTHH:MM:SS",
+          "tooltip": "Range consists of start_date and end_date separated by `TO`. Both start and end values can be in either date-only or full datetime format.",
+          "description": "Filter by modified datetime range. Accepted formats: (`YYYY-MM-DDTHH:MM:SS TO YYYY-MM-DDTHH:MM:SS`), (`YYYY-MM-DD TO YYYY-MM-DD`). Example: (`2022-03-25T09:50:21.770+00:00 TO 2022-03-25T14:24:05.000+00:00`, `2022-03-25TO2022-03-25T14:24:05.000+00:00`, `2022-03-25 TO 2022-03-25`)"
         },
         {
           "name": "page",
@@ -3407,7 +3613,9 @@
           {
             "text": "",
             "user_name": "",
-            "comment_type": ""
+            "comment_type": "",
+            "created_ts": "",
+            "modified_ts": ""
           }
         ],
         "page": "",
@@ -3439,6 +3647,28 @@
             "System",
             "User"
           ]
+        },
+        {
+          "title": "Create timestamp",
+          "name": "created_ts",
+          "type": "text",
+          "visible": true,
+          "editable": true,
+          "required": false,
+          "placeholder": "Format: YYYY-MM-DDTHH:MM:SS TO YYYY-MM-DDTHH:MM:SS",
+          "tooltip": "Range consists of start_date and end_date separated by `TO`. Both start and end values can be in either date-only or full datetime format.",
+          "description": "Filter by created_ts datetime range. Accepted formats: (`YYYY-MM-DDTHH:MM:SS TO YYYY-MM-DDTHH:MM:SS`), (`YYYY-MM-DD TO YYYY-MM-DD`). Example: (`2022-03-25T09:50:21.770+00:00 TO 2022-03-25T14:24:05.000+00:00`, `2022-03-25TO2022-03-25T14:24:05.000+00:00`, `2022-03-25 TO 2022-03-25`)"
+        },
+        {
+          "title": "Modified timestamp",
+          "name": "modified_ts",
+          "type": "text",
+          "visible": true,
+          "editable": true,
+          "required": false,
+          "placeholder": "Format: YYYY-MM-DDTHH:MM:SS TO YYYY-MM-DDTHH:MM:SS",
+          "tooltip": "Range consists of start_date and end_date separated by `TO`. Both start and end values can be in either date-only or full datetime format.",
+          "description": "Filter by modified datetime range. Accepted formats: (`YYYY-MM-DDTHH:MM:SS TO YYYY-MM-DDTHH:MM:SS`), (`YYYY-MM-DD TO YYYY-MM-DD`). Example: (`2022-03-25T09:50:21.770+00:00 TO 2022-03-25T14:24:05.000+00:00`, `2022-03-25TO2022-03-25T14:24:05.000+00:00`, `2022-03-25 TO 2022-03-25`)"
         },
         {
           "name": "page",
@@ -3479,7 +3709,9 @@
           {
             "text": "",
             "user_name": "",
-            "comment_type": ""
+            "comment_type": "",
+            "created_ts": "",
+            "modified_ts": ""
           }
         ],
         "page": "",
@@ -3510,6 +3742,28 @@
             "System",
             "User"
           ]
+        },
+        {
+          "title": "Create timestamp",
+          "name": "created_ts",
+          "type": "text",
+          "visible": true,
+          "editable": true,
+          "required": false,
+          "placeholder": "Format: YYYY-MM-DDTHH:MM:SS TO YYYY-MM-DDTHH:MM:SS",
+          "tooltip": "Range consists of start_date and end_date separated by `TO`. Both start and end values can be in either date-only or full datetime format.",
+          "description": "Filter by created_ts datetime range. Accepted formats: (`YYYY-MM-DDTHH:MM:SS TO YYYY-MM-DDTHH:MM:SS`), (`YYYY-MM-DD TO YYYY-MM-DD`). Example: (`2022-03-25T09:50:21.770+00:00 TO 2022-03-25T14:24:05.000+00:00`, `2022-03-25TO2022-03-25T14:24:05.000+00:00`, `2022-03-25 TO 2022-03-25`)"
+        },
+        {
+          "title": "Modified timestamp",
+          "name": "modified_ts",
+          "type": "text",
+          "visible": true,
+          "editable": true,
+          "required": false,
+          "placeholder": "Format: YYYY-MM-DDTHH:MM:SS TO YYYY-MM-DDTHH:MM:SS",
+          "tooltip": "Range consists of start_date and end_date separated by `TO`. Both start and end values can be in either date-only or full datetime format.",
+          "description": "Filter by modified datetime range. Accepted formats: (`YYYY-MM-DDTHH:MM:SS TO YYYY-MM-DDTHH:MM:SS`), (`YYYY-MM-DD TO YYYY-MM-DD`). Example: (`2022-03-25T09:50:21.770+00:00 TO 2022-03-25T14:24:05.000+00:00`, `2022-03-25TO2022-03-25T14:24:05.000+00:00`, `2022-03-25 TO 2022-03-25`)"
         },
         {
           "name": "page",
@@ -3552,7 +3806,9 @@
             "name": "",
             "scope": "",
             "description": "",
-            "linked_assets_count": ""
+            "linked_assets_count": "",
+            "created_ts": "",
+            "modified_ts": ""
           }
         ],
         "page": "",
@@ -3583,6 +3839,28 @@
           "required": false,
           "tooltip": "Specify the name of tag which you want to retrieve. Name are matched partially.",
           "description": "(Optional) Specify the name of tag to retrieve. Names are matched partially."
+        },
+        {
+          "title": "Create timestamp",
+          "name": "created_ts",
+          "type": "text",
+          "visible": true,
+          "editable": true,
+          "required": false,
+          "placeholder": "Format: YYYY-MM-DDTHH:MM:SS TO YYYY-MM-DDTHH:MM:SS",
+          "tooltip": "Range consists of start_date and end_date separated by `TO`. Both start and end values can be in either date-only or full datetime format.",
+          "description": "Filter by created_ts datetime range. Accepted formats: (`YYYY-MM-DDTHH:MM:SS TO YYYY-MM-DDTHH:MM:SS`), (`YYYY-MM-DD TO YYYY-MM-DD`). Example: (`2022-03-25T09:50:21.770+00:00 TO 2022-03-25T14:24:05.000+00:00`, `2022-03-25TO2022-03-25T14:24:05.000+00:00`, `2022-03-25 TO 2022-03-25`)"
+        },
+        {
+          "title": "Modified timestamp",
+          "name": "modified_ts",
+          "type": "text",
+          "visible": true,
+          "editable": true,
+          "required": false,
+          "placeholder": "Format: YYYY-MM-DDTHH:MM:SS TO YYYY-MM-DDTHH:MM:SS",
+          "tooltip": "Range consists of start_date and end_date separated by `TO`. Both start and end values can be in either date-only or full datetime format.",
+          "description": "Filter by modified datetime range. Accepted formats: (`YYYY-MM-DDTHH:MM:SS TO YYYY-MM-DDTHH:MM:SS`), (`YYYY-MM-DD TO YYYY-MM-DD`). Example: (`2022-03-25T09:50:21.770+00:00 TO 2022-03-25T14:24:05.000+00:00`, `2022-03-25TO2022-03-25T14:24:05.000+00:00`, `2022-03-25 TO 2022-03-25`)"
         },
         {
           "name": "page",
@@ -3627,7 +3905,9 @@
             "scope": "",
             "description": "",
             "linked_assets": [],
-            "linked_assets_count": ""
+            "linked_assets_count": "",
+            "created_ts": "",
+            "modified_ts": ""
           }
         },
         {
@@ -3637,7 +3917,9 @@
             "name": "",
             "scope": "",
             "description": "",
-            "linked_assets_count": ""
+            "linked_assets_count": "",
+            "created_ts": "",
+            "modified_ts": ""
           }
         }
       ],
@@ -3681,7 +3963,9 @@
             "name": "",
             "scope": "",
             "description": "",
-            "linked_assets_count": ""
+            "linked_assets_count": "",
+            "created_ts": "",
+            "modified_ts": ""
           }
         ],
         "page": "",
@@ -3712,6 +3996,28 @@
           "required": false,
           "tooltip": "Specify the name of group which you want to retrieve. Name are matched partially.",
           "description": "(Optional) Specify the name of group which you want to retrieve. Name are matched partially."
+        },
+        {
+          "title": "Create timestamp",
+          "name": "created_ts",
+          "type": "text",
+          "visible": true,
+          "editable": true,
+          "required": false,
+          "placeholder": "Format: YYYY-MM-DDTHH:MM:SS TO YYYY-MM-DDTHH:MM:SS",
+          "tooltip": "Range consists of start_date and end_date separated by `TO`. Both start and end values can be in either date-only or full datetime format.",
+          "description": "Filter by created_ts datetime range. Accepted formats: (`YYYY-MM-DDTHH:MM:SS TO YYYY-MM-DDTHH:MM:SS`), (`YYYY-MM-DD TO YYYY-MM-DD`). Example: (`2022-03-25T09:50:21.770+00:00 TO 2022-03-25T14:24:05.000+00:00`, `2022-03-25TO2022-03-25T14:24:05.000+00:00`, `2022-03-25 TO 2022-03-25`)"
+        },
+        {
+          "title": "Modified timestamp",
+          "name": "modified_ts",
+          "type": "text",
+          "visible": true,
+          "editable": true,
+          "required": false,
+          "placeholder": "Format: YYYY-MM-DDTHH:MM:SS TO YYYY-MM-DDTHH:MM:SS",
+          "tooltip": "Range consists of start_date and end_date separated by `TO`. Both start and end values can be in either date-only or full datetime format.",
+          "description": "Filter by modified datetime range. Accepted formats: (`YYYY-MM-DDTHH:MM:SS TO YYYY-MM-DDTHH:MM:SS`), (`YYYY-MM-DD TO YYYY-MM-DD`). Example: (`2022-03-25T09:50:21.770+00:00 TO 2022-03-25T14:24:05.000+00:00`, `2022-03-25TO2022-03-25T14:24:05.000+00:00`, `2022-03-25 TO 2022-03-25`)"
         },
         {
           "name": "page",
@@ -3756,7 +4062,9 @@
             "scope": "",
             "description": "",
             "linked_assets": [],
-            "linked_assets_count": ""
+            "linked_assets_count": "",
+            "created_ts": "",
+            "modified_ts": ""
           }
         },
         {
@@ -3766,7 +4074,9 @@
             "name": "",
             "scope": "",
             "description": "",
-            "linked_assets_count": ""
+            "linked_assets_count": "",
+            "created_ts": "",
+            "modified_ts": ""
           }
         }
       ],

--- a/fortinet-fortirecon-easm/info.json
+++ b/fortinet-fortirecon-easm/info.json
@@ -155,7 +155,7 @@
         },
         {
           "name": "show_plaintext_password",
-          "title": "Show plaintext password",
+          "title": "Show Plaintext Password",
           "type": "select",
           "editable": true,
           "visible": true,
@@ -388,10 +388,10 @@
           "tooltip": "Select the nvd severity to filter the results.",
           "description": "(Optional) Select the nvd severity to filter the results. You can choose from the following options: Critical, High, Medium or Low",
           "options": [
-            "critical",
-            "high",
-            "medium",
-            "low"
+            "Critical",
+            "High",
+            "Medium",
+            "Low"
           ]
         },
         {
@@ -404,10 +404,10 @@
           "tooltip": "Select the recon severity to filter the results.",
           "description": "(Optional) Select the recon severity to filter the results. You can choose from the following options: Critical, High, Medium or Low",
           "options": [
-            "critical",
-            "high",
-            "medium",
-            "low"
+            "Critical",
+            "High",
+            "Medium",
+            "Low"
           ]
         },
         {
@@ -558,7 +558,7 @@
           ]
         },
         {
-          "title": "Create timestamp",
+          "title": "Created Time",
           "name": "created_ts",
           "type": "text",
           "visible": true,
@@ -569,7 +569,7 @@
           "description": "Filter by created_ts datetime range. Accepted formats: (`YYYY-MM-DDTHH:MM:SS TO YYYY-MM-DDTHH:MM:SS`), (`YYYY-MM-DD TO YYYY-MM-DD`). Example: (`2022-03-25T09:50:21.770+00:00 TO 2022-03-25T14:24:05.000+00:00`, `2022-03-25TO2022-03-25T14:24:05.000+00:00`, `2022-03-25 TO 2022-03-25`) "
         },
         {
-          "title": "Modified timestamp",
+          "title": "Modified Time",
           "name": "modified_ts",
           "type": "text",
           "visible": true,
@@ -860,7 +860,7 @@
           "description": "(Optional) Specify the group ID to filter retrieved results. You can specify multiple group IDs as comma-separated values. It returns results if it matches all of the specified groups, operating as an 'AND filter'."
         },
         {
-          "title": "Create timestamp",
+          "title": "Created Time",
           "name": "created_ts",
           "type": "text",
           "visible": true,
@@ -871,7 +871,7 @@
           "description": "Filter by created_ts datetime range. Accepted formats: (`YYYY-MM-DDTHH:MM:SS TO YYYY-MM-DDTHH:MM:SS`), (`YYYY-MM-DD TO YYYY-MM-DD`). Example: (`2022-03-25T09:50:21.770+00:00 TO 2022-03-25T14:24:05.000+00:00`, `2022-03-25TO2022-03-25T14:24:05.000+00:00`, `2022-03-25 TO 2022-03-25`)"
         },
         {
-          "title": "Modified timestamp",
+          "title": "Modified Time",
           "name": "modified_ts",
           "type": "text",
           "visible": true,
@@ -1031,7 +1031,7 @@
           "description": "(Optional) Specify the group ID to filter retrieved results. You can specify multiple group IDs as comma-separated values. It returns results if it matches all of the specified groups, operating as an 'AND filter'."
         },
         {
-          "title": "Create timestamp",
+          "title": "Created Time",
           "name": "created_ts",
           "type": "text",
           "visible": true,
@@ -1042,7 +1042,7 @@
           "description": "Filter by created_ts datetime range. Accepted formats: (`YYYY-MM-DDTHH:MM:SS TO YYYY-MM-DDTHH:MM:SS`), (`YYYY-MM-DD TO YYYY-MM-DD`). Example: (`2022-03-25T09:50:21.770+00:00 TO 2022-03-25T14:24:05.000+00:00`, `2022-03-25TO2022-03-25T14:24:05.000+00:00`, `2022-03-25 TO 2022-03-25`)"
         },
         {
-          "title": "Modified timestamp",
+          "title": "Modified Time",
           "name": "modified_ts",
           "type": "text",
           "visible": true,
@@ -1225,7 +1225,7 @@
           "description": "(Optional) Specify the cloud metadata in JSON format to filter the results. Available fields are: integration_id, cloud_provider, account_id, resource_id, resource_group, resource_name, resource_type, region, and subscription_id. For example: { \"cloud_provider\": [ \"azure\" ], \"region\": [ \"westus2\" ], \"integration_id\": [ \"777408f550e5rrdd1hjf3w90\" ], \"resource_name\": [ \"TestAssetsPublic\" ] }"
         },
         {
-          "title": "Create timestamp",
+          "title": "Created Time",
           "name": "created_ts",
           "type": "text",
           "visible": true,
@@ -1236,7 +1236,7 @@
           "description": "Filter by created_ts datetime range. Accepted formats: (`YYYY-MM-DDTHH:MM:SS TO YYYY-MM-DDTHH:MM:SS`), (`YYYY-MM-DD TO YYYY-MM-DD`). Example: (`2022-03-25T09:50:21.770+00:00 TO 2022-03-25T14:24:05.000+00:00`, `2022-03-25TO2022-03-25T14:24:05.000+00:00`, `2022-03-25 TO 2022-03-25`)"
         },
         {
-          "title": "Modified timestamp",
+          "title": "Modified Time",
           "name": "modified_ts",
           "type": "text",
           "visible": true,
@@ -1601,7 +1601,7 @@
           "description": "(Optional) Specify the cloud metadata in JSON format to filter the results. Available fields are: integration_id, cloud_provider, account_id, resource_id, resource_group, resource_name, resource_type, region, and subscription_id. For example: { \"cloud_provider\": [ \"azure\" ], \"region\": [ \"westus2\" ], \"integration_id\": [ \"777408f550e5rrdd1hjf3w90\" ], \"resource_name\": [ \"TestAssetsPublic\" ] }"
         },
         {
-          "title": "Create timestamp",
+          "title": "Created Time",
           "name": "created_ts",
           "type": "text",
           "visible": true,
@@ -1612,7 +1612,7 @@
           "description": "Filter by created_ts datetime range. Accepted formats: (`YYYY-MM-DDTHH:MM:SS TO YYYY-MM-DDTHH:MM:SS`), (`YYYY-MM-DD TO YYYY-MM-DD`). Example: (`2022-03-25T09:50:21.770+00:00 TO 2022-03-25T14:24:05.000+00:00`, `2022-03-25TO2022-03-25T14:24:05.000+00:00`, `2022-03-25 TO 2022-03-25`)"
         },
         {
-          "title": "Modified timestamp",
+          "title": "Modified Time",
           "name": "modified_ts",
           "type": "text",
           "visible": true,
@@ -2040,7 +2040,7 @@
           "description": "(Optional) Specify the cloud metadata in JSON format to filter the results. Available fields are: integration_id, cloud_provider, account_id, resource_id, resource_group, resource_name, resource_type, region, and subscription_id. For example: { \"cloud_provider\": [ \"azure\" ], \"region\": [ \"westus2\" ], \"integration_id\": [ \"777408f550e5rrdd1hjf3w90\" ], \"resource_name\": [ \"TestAssetsPublic\" ] }"
         },
         {
-          "title": "Create timestamp",
+          "title": "Created Time",
           "name": "created_ts",
           "type": "text",
           "visible": true,
@@ -2051,7 +2051,7 @@
           "description": "Filter by created_ts datetime range. Accepted formats: (`YYYY-MM-DDTHH:MM:SS TO YYYY-MM-DDTHH:MM:SS`), (`YYYY-MM-DD TO YYYY-MM-DD`). Example: (`2022-03-25T09:50:21.770+00:00 TO 2022-03-25T14:24:05.000+00:00`, `2022-03-25TO2022-03-25T14:24:05.000+00:00`, `2022-03-25 TO 2022-03-25`)"
         },
         {
-          "title": "Modified timestamp",
+          "title": "Modified Time",
           "name": "modified_ts",
           "type": "text",
           "visible": true,
@@ -2366,7 +2366,7 @@
           "description": "(Optional) Specify the cloud metadata in JSON format to filter the results. Available fields are: integration_id, cloud_provider, account_id, resource_id, resource_group, resource_name, resource_type, region, and subscription_id. For example: { \"cloud_provider\": [ \"azure\" ], \"region\": [ \"westus2\" ], \"integration_id\": [ \"777408f550e5rrdd1hjf3w90\" ], \"resource_name\": [ \"TestAssetsPublic\" ] }"
         },
         {
-          "title": "Create timestamp",
+          "title": "Created Time",
           "name": "created_ts",
           "type": "text",
           "visible": true,
@@ -2377,7 +2377,7 @@
           "description": "Filter by created_ts datetime range. Accepted formats: (`YYYY-MM-DDTHH:MM:SS TO YYYY-MM-DDTHH:MM:SS`), (`YYYY-MM-DD TO YYYY-MM-DD`). Example: (`2022-03-25T09:50:21.770+00:00 TO 2022-03-25T14:24:05.000+00:00`, `2022-03-25TO2022-03-25T14:24:05.000+00:00`, `2022-03-25 TO 2022-03-25`)"
         },
         {
-          "title": "Modified timestamp",
+          "title": "Modified Time",
           "name": "modified_ts",
           "type": "text",
           "visible": true,
@@ -2727,7 +2727,7 @@
           "description": "(Optional) Specify the cloud metadata in JSON format to filter the results. Available fields are: integration_id, cloud_provider, account_id, resource_id, resource_group, resource_name, resource_type, region, and subscription_id. For example: { \"cloud_provider\": [ \"azure\" ], \"region\": [ \"westus2\" ], \"integration_id\": [ \"777408f550e5rrdd1hjf3w90\" ], \"resource_name\": [ \"TestAssetsPublic\" ] }"
         },
         {
-          "title": "Create timestamp",
+          "title": "Created Time",
           "name": "created_ts",
           "type": "text",
           "visible": true,
@@ -2738,7 +2738,7 @@
           "description": "Filter by created_ts datetime range. Accepted formats: (`YYYY-MM-DDTHH:MM:SS TO YYYY-MM-DDTHH:MM:SS`), (`YYYY-MM-DD TO YYYY-MM-DD`). Example: (`2022-03-25T09:50:21.770+00:00 TO 2022-03-25T14:24:05.000+00:00`, `2022-03-25TO2022-03-25T14:24:05.000+00:00`, `2022-03-25 TO 2022-03-25`)"
         },
         {
-          "title": "Modified timestamp",
+          "title": "Modified Time",
           "name": "modified_ts",
           "type": "text",
           "visible": true,
@@ -3360,7 +3360,7 @@
           ]
         },
         {
-          "title": "Create timestamp",
+          "title": "Created Time",
           "name": "created_ts",
           "type": "text",
           "visible": true,
@@ -3371,7 +3371,7 @@
           "description": "Filter by created_ts datetime range. Accepted formats: (`YYYY-MM-DDTHH:MM:SS TO YYYY-MM-DDTHH:MM:SS`), (`YYYY-MM-DD TO YYYY-MM-DD`). Example: (`2022-03-25T09:50:21.770+00:00 TO 2022-03-25T14:24:05.000+00:00`, `2022-03-25TO2022-03-25T14:24:05.000+00:00`, `2022-03-25 TO 2022-03-25`)"
         },
         {
-          "title": "Modified timestamp",
+          "title": "Modified Time",
           "name": "modified_ts",
           "type": "text",
           "visible": true,
@@ -3462,7 +3462,7 @@
           ]
         },
         {
-          "title": "Create timestamp",
+          "title": "Created Time",
           "name": "created_ts",
           "type": "text",
           "visible": true,
@@ -3473,7 +3473,7 @@
           "description": "Filter by created_ts datetime range. Accepted formats: (`YYYY-MM-DDTHH:MM:SS TO YYYY-MM-DDTHH:MM:SS`), (`YYYY-MM-DD TO YYYY-MM-DD`). Example: (`2022-03-25T09:50:21.770+00:00 TO 2022-03-25T14:24:05.000+00:00`, `2022-03-25TO2022-03-25T14:24:05.000+00:00`, `2022-03-25 TO 2022-03-25`)"
         },
         {
-          "title": "Modified timestamp",
+          "title": "Modified Time",
           "name": "modified_ts",
           "type": "text",
           "visible": true,
@@ -3551,7 +3551,7 @@
           ]
         },
         {
-          "title": "Create timestamp",
+          "title": "Created Time",
           "name": "created_ts",
           "type": "text",
           "visible": true,
@@ -3562,7 +3562,7 @@
           "description": "Filter by created_ts datetime range. Accepted formats: (`YYYY-MM-DDTHH:MM:SS TO YYYY-MM-DDTHH:MM:SS`), (`YYYY-MM-DD TO YYYY-MM-DD`). Example: (`2022-03-25T09:50:21.770+00:00 TO 2022-03-25T14:24:05.000+00:00`, `2022-03-25TO2022-03-25T14:24:05.000+00:00`, `2022-03-25 TO 2022-03-25`)"
         },
         {
-          "title": "Modified timestamp",
+          "title": "Modified Time",
           "name": "modified_ts",
           "type": "text",
           "visible": true,
@@ -3698,7 +3698,7 @@
           ]
         },
         {
-          "title": "Create timestamp",
+          "title": "Created Time",
           "name": "created_ts",
           "type": "text",
           "visible": true,
@@ -3709,7 +3709,7 @@
           "description": "Filter by created_ts datetime range. Accepted formats: (`YYYY-MM-DDTHH:MM:SS TO YYYY-MM-DDTHH:MM:SS`), (`YYYY-MM-DD TO YYYY-MM-DD`). Example: (`2022-03-25T09:50:21.770+00:00 TO 2022-03-25T14:24:05.000+00:00`, `2022-03-25TO2022-03-25T14:24:05.000+00:00`, `2022-03-25 TO 2022-03-25`)"
         },
         {
-          "title": "Modified timestamp",
+          "title": "Modified Time",
           "name": "modified_ts",
           "type": "text",
           "visible": true,
@@ -3793,7 +3793,7 @@
           ]
         },
         {
-          "title": "Create timestamp",
+          "title": "Created Time",
           "name": "created_ts",
           "type": "text",
           "visible": true,
@@ -3804,7 +3804,7 @@
           "description": "Filter by created_ts datetime range. Accepted formats: (`YYYY-MM-DDTHH:MM:SS TO YYYY-MM-DDTHH:MM:SS`), (`YYYY-MM-DD TO YYYY-MM-DD`). Example: (`2022-03-25T09:50:21.770+00:00 TO 2022-03-25T14:24:05.000+00:00`, `2022-03-25TO2022-03-25T14:24:05.000+00:00`, `2022-03-25 TO 2022-03-25`)"
         },
         {
-          "title": "Modified timestamp",
+          "title": "Modified Time",
           "name": "modified_ts",
           "type": "text",
           "visible": true,
@@ -3890,7 +3890,7 @@
           "description": "(Optional) Specify the name of tag to retrieve. Names are matched partially."
         },
         {
-          "title": "Create timestamp",
+          "title": "Created Time",
           "name": "created_ts",
           "type": "text",
           "visible": true,
@@ -3901,7 +3901,7 @@
           "description": "Filter by created_ts datetime range. Accepted formats: (`YYYY-MM-DDTHH:MM:SS TO YYYY-MM-DDTHH:MM:SS`), (`YYYY-MM-DD TO YYYY-MM-DD`). Example: (`2022-03-25T09:50:21.770+00:00 TO 2022-03-25T14:24:05.000+00:00`, `2022-03-25TO2022-03-25T14:24:05.000+00:00`, `2022-03-25 TO 2022-03-25`)"
         },
         {
-          "title": "Modified timestamp",
+          "title": "Modified Time",
           "name": "modified_ts",
           "type": "text",
           "visible": true,
@@ -4047,7 +4047,7 @@
           "description": "(Optional) Specify the name of group which you want to retrieve. Name are matched partially."
         },
         {
-          "title": "Create timestamp",
+          "title": "Created Time",
           "name": "created_ts",
           "type": "text",
           "visible": true,
@@ -4058,7 +4058,7 @@
           "description": "Filter by created_ts datetime range. Accepted formats: (`YYYY-MM-DDTHH:MM:SS TO YYYY-MM-DDTHH:MM:SS`), (`YYYY-MM-DD TO YYYY-MM-DD`). Example: (`2022-03-25T09:50:21.770+00:00 TO 2022-03-25T14:24:05.000+00:00`, `2022-03-25TO2022-03-25T14:24:05.000+00:00`, `2022-03-25 TO 2022-03-25`)"
         },
         {
-          "title": "Modified timestamp",
+          "title": "Modified Time",
           "name": "modified_ts",
           "type": "text",
           "visible": true,

--- a/fortinet-fortirecon-easm/info.json
+++ b/fortinet-fortirecon-easm/info.json
@@ -519,7 +519,7 @@
           "required": false,
           "placeholder": "Format: YYYY-MM-DDTHH:MM:SS TO YYYY-MM-DDTHH:MM:SS",
           "tooltip": "Range consists of start_date and end_date separated by `TO`. Both start and end values can be in either date-only or full datetime format.",
-          "description": "Filter by created_ts datetime range. Accepted formats: (`YYYY-MM-DDTHH:MM:SS TO YYYY-MM-DDTHH:MM:SS`), (`YYYY-MM-DD TO YYYY-MM-DD`). Example: (`2022-03-25T09:50:21.770+00:00 TO 2022-03-25T14:24:05.000+00:00`, `2022-03-25TO2022-03-25T14:24:05.000+00:00`, `2022-03-25 TO 2022-03-25`)"
+          "description": "Filter by created_ts datetime range. Accepted formats: (`YYYY-MM-DDTHH:MM:SS TO YYYY-MM-DDTHH:MM:SS`), (`YYYY-MM-DD TO YYYY-MM-DD`). Example: (`2022-03-25T09:50:21.770+00:00 TO 2022-03-25T14:24:05.000+00:00`, `2022-03-25TO2022-03-25T14:24:05.000+00:00`, `2022-03-25 TO 2022-03-25`) "
         },
         {
           "title": "Modified timestamp",

--- a/fortinet-fortirecon-easm/info.json
+++ b/fortinet-fortirecon-easm/info.json
@@ -315,6 +315,8 @@
             "asset_type": "",
             "country": "",
             "severity": "",
+            "nvd_severity": "",
+            "recon_severity": "",
             "port": "",
             "bucket": "",
             "status": "",
@@ -360,6 +362,38 @@
             "High",
             "Medium",
             "Low"
+          ]
+        },
+        {
+          "name": "nvd_severity",
+          "title": "NVD Severity",
+          "type": "select",
+          "editable": true,
+          "visible": true,
+          "required": false,
+          "tooltip": "Select the nvd severity to filter the results.",
+          "description": "(Optional) Select the nvd severity to filter the results. You can choose from the following options: Critical, High, Medium or Low",
+          "options": [
+            "critical",
+            "high",
+            "medium",
+            "low"
+          ]
+        },
+        {
+          "name": "recon_severity",
+          "title": "Recon Severity",
+          "type": "select",
+          "editable": true,
+          "visible": true,
+          "required": false,
+          "tooltip": "Select the recon severity to filter the results.",
+          "description": "(Optional) Select the recon severity to filter the results. You can choose from the following options: Critical, High, Medium or Low",
+          "options": [
+            "critical",
+            "high",
+            "medium",
+            "low"
           ]
         },
         {
@@ -585,6 +619,8 @@
         "asset_type": "",
         "country": "",
         "severity": "",
+        "nvd_severity": "",
+        "recon_severity": "",
         "port": "",
         "bucket": "",
         "status": "",

--- a/fortinet-fortirecon-easm/info.json
+++ b/fortinet-fortirecon-easm/info.json
@@ -314,6 +314,8 @@
             "asset_type": "",
             "country": "",
             "severity": "",
+            "nvd_severity": "",
+            "recon_severity": "",
             "port": "",
             "bucket": "",
             "status": "",
@@ -359,6 +361,38 @@
             "High",
             "Medium",
             "Low"
+          ]
+        },
+        {
+          "name": "nvd_severity",
+          "title": "NVD Severity",
+          "type": "select",
+          "editable": true,
+          "visible": true,
+          "required": false,
+          "tooltip": "Select the nvd severity to filter the results.",
+          "description": "(Optional) Select the nvd severity to filter the results. You can choose from the following options: Critical, High, Medium or Low",
+          "options": [
+            "critical",
+            "high",
+            "medium",
+            "low"
+          ]
+        },
+        {
+          "name": "recon_severity",
+          "title": "Recon Severity",
+          "type": "select",
+          "editable": true,
+          "visible": true,
+          "required": false,
+          "tooltip": "Select the recon severity to filter the results.",
+          "description": "(Optional) Select the recon severity to filter the results. You can choose from the following options: Critical, High, Medium or Low",
+          "options": [
+            "critical",
+            "high",
+            "medium",
+            "low"
           ]
         },
         {

--- a/fortinet-fortirecon-easm/issues.py
+++ b/fortinet-fortirecon-easm/issues.py
@@ -19,9 +19,11 @@ def get_issues_discovered(config, params):
     asset_type = params.get("asset_type")
     if status:
         params["status"] = STATUS_MAPPING.get(status)
-    severity = params.get("severity")
-    if severity:
-        params["severity"] = SEVERITY_MAPPING.get(severity)
+
+    sev_params = ["severity", "nvd_severity", "recon_severity"]
+    for sev in sev_params:
+        _map_severity_value(params, sev)
+
     if asset_type:
         params["asset_type"] = ASSET_TYPE_MAPPING.get(asset_type)
     bucket_id = params.get("bucket_id")
@@ -144,3 +146,8 @@ def update_issue_status(config, params):
     print(endpoint)
     response = MK.make_request(endpoint=endpoint, method="PATCH", params=params, data=payload)
     return response
+
+def _map_severity_value(params: dict, sev_param: str):
+    severity = params.get(sev_param)
+    if severity:
+        params[sev_param] = SEVERITY_MAPPING.get(severity)

--- a/fortinet-fortirecon-easm/release_notes.md
+++ b/fortinet-fortirecon-easm/release_notes.md
@@ -1,16 +1,21 @@
 #### The following enhancements have been made to the Fortinet FortiRecon EASM Connector in version 1.2.0:
 
-- Added the following new actions and playbooks:
-
-    - Mark Archived Issue as Active
-    - Update Issue Status
-    - Update Archived Asset
-    - Update ASN Asset To False Positive
-    - Update IP Prefix Asset To False Positive
-    - Update IP Asset To False Positive
-    - Update Domain Asset To False Positive
-    - Update Sub-Domain Asset To False Positive
-    - Update Leaked Credential Status
-- Updated output schemas of `Get Domains` and `Get Breaches by ID` actions.
-- Support for notifications from FortiSOAR SaaS to client servers enabling clients to
-  take appropriate actions.
+- Update the following actions in playbooks:
+    - Added new query param `show_plaintest_password` in Get Leaked Credentials action
+    - Added new query param and output schema for fields `recon_severity` and `nvd_severity` in Get Issues Discovered action.
+    - Added daterange filter `created_ts` and `updated_ts` for below actions-
+      - Get Issues Discovered
+      - Get Archived Issues
+      - Get Ips
+      - Get Domains
+      - Get Subdomains
+      - Get Prefixes
+      - Get Asset Asns
+      - Get Exposed Services
+      - Get Archived Assets
+      - Get Cloud Integrations
+      - Get Fgt Integrations
+      - Get Archived Issue Comments
+      - Get Issue Comments
+      - Get Tags
+      - Get Groups

--- a/fortinet-fortirecon-easm/release_notes.md
+++ b/fortinet-fortirecon-easm/release_notes.md
@@ -1,9 +1,9 @@
 #### The following enhancements have been made to the Fortinet FortiRecon EASM Connector in version 1.2.0:
 
 - Update the following actions in playbooks:
-    - Added new query param `show_plaintest_password` in Get Leaked Credentials action
+    - Added new query param `show_plaintext_password` in Get Leaked Credentials action
     - Added new query param and output schema for fields `recon_severity` and `nvd_severity` in Get Issues Discovered action.
-    - Added daterange filter `created_ts` and `updated_ts` for below actions-
+    - Added daterange filter `created_ts` and `modified_ts` for below actions-
       - Get Issues Discovered
       - Get Archived Issues
       - Get Ips

--- a/fortinet-fortirecon-easm/release_notes.md
+++ b/fortinet-fortirecon-easm/release_notes.md
@@ -1,9 +1,9 @@
 #### The following enhancements have been made to the Fortinet FortiRecon EASM Connector in version 1.2.0:
 
 - Update the following actions in playbooks:
-    - Added new query param `show_plaintext_password` in Get Leaked Credentials action
-    - Added new query param and output schema for fields `recon_severity` and `nvd_severity` in Get Issues Discovered action.
-    - Added daterange filter `created_ts` and `modified_ts` for below actions-
+    - Added new query param `Show Plaintext Password` in Get Leaked Credentials action
+    - Added new query param and output schema for fields `Recon Severity` and `NVD Severity` in Get Issues Discovered action.
+    - Added daterange filter `Created Time` and `Modified Time` for below actions-
       - Get Issues Discovered
       - Get Archived Issues
       - Get Ips


### PR DESCRIPTION
#### Descriptions:
Added new field called show_plaintest_password in get_leaked_credentials
Updated request response params for get_issues_discovered 
Added filter params created_ts and modified_ts for below operations:
get_issues_discovered
get_archived_issues
get_ips
get_domains
get_subdomains
get_prefixes
get_asset_asns
get_exposed_services
get_archived_assets
get_cloud_integrations
get_fgt_integrations
get_archived_issue_comments
get_issue_comments
get_tags
get_groups


#### Fix:
Updated all above operations

