### PR TITLE
 fix(4): Added placeholder for exposed services action

### DIFF
--- a/fortinet-fortirecon-easm/info.json
+++ b/fortinet-fortirecon-easm/info.json
@@ -3328,7 +3328,8 @@
           "editable": true,
           "visible": true,
           "required": false,
-          "tooltip": "Specify the keywords in the service banner, to filter the results, from retrieved exposed services. Note: Please do not use *, it is implicitly added.",
+          "tooltip": "Specify the keywords in the service banner, to filter the results, from retrieved exposed services. Note: Please do not use *, it is implicitly added.  Allowed special characters are [.-/]",
+          "placeholder": "For example: <This is , a banner>, Then Search with: <banner>",
           "description": "(Optional) Specify the keywords in the service banner to filter the retrieved exposed services. NOTE: Do not use *; it is added implicitly."
         },
         {


### PR DESCRIPTION
#### Descriptions:
Mantis created due to unclear message for request param service banner in get exposed services.

#### Fix:
Added placeholder for get exposed services actions

